### PR TITLE
Fix typo in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ cmake ..
 make
 ```
 
-You can open the project in Gitpod, a free online dev evironment for GitHub:
+You can open the project in Gitpod, a free online development environment for GitHub:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ssloy/tinyraytracer)
 


### PR DESCRIPTION
## Summary
- fix a typo in `Readme.md` on line 20

## Testing
- `grep -n "development environment" -n Readme.md`

------
https://chatgpt.com/codex/tasks/task_e_6846d1c3a8d0832eaefb70fa6bc5ec2c